### PR TITLE
Fix error tracing

### DIFF
--- a/src/stub/precomp.h
+++ b/src/stub/precomp.h
@@ -4,6 +4,10 @@
 
 #include <windows.h>
 
+#include <dutilsources.h>
+
+#define DUTIL_SOURCE_DEFAULT DUTIL_SOURCE_EXTERNAL
+
 #include <dutil.h>
 #include <apputil.h>
 #include <strutil.h>


### PR DESCRIPTION
DUTIL_SOURCE_DEFAULT wasn't defined the same in the stub and engine.lib.

Sorry @barnson, this probably made it impossible to understand the problems in x64.