### PR TITLE
Cleanup should always be attempted, and add some logging for it.

### DIFF
--- a/src/engine/core.h
+++ b/src/engine/core.h
@@ -204,7 +204,7 @@ HRESULT CoreAppendFileHandleSelfToCommandLine(
     __deref_inout_z LPWSTR* psczCommandLine,
     __deref_inout_z_opt LPWSTR* psczObfuscatedCommandLine
     );
-HRESULT CoreCleanup(
+void CoreCleanup(
     __in BURN_ENGINE_STATE* pEngineState
     );
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -592,13 +592,12 @@ static HRESULT RunNormal(
         ExitOnFailure(hr, "Failed while running ");
     } while (fReloadApp);
 
+LExit:
     if (!fSkipCleanup)
     {
-        hr = CoreCleanup(pEngineState);
-        ExitOnFailure(hr, "Failed to cleanup before shutting down");
+        CoreCleanup(pEngineState);
     }
 
-LExit:
     BurnExtensionUnload(&pEngineState->extensions);
 
     // If the message window is still around, close it.

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -776,6 +776,12 @@ static HRESULT RunApplication(
         }
         else
         {
+            // When the BA makes a request from its own thread, it's common for the PostThreadMessage in externalengine.cpp
+            // to block until this thread waits on something. It's also common for Detect and Plan to never wait on something.
+            // In the extreme case, the engine could be elevating in Apply before the Detect call returned to the BA.
+            // This helps to avoid that situation, which could be blocking a UI thread.
+            ::Sleep(0);
+
             ProcessMessage(pEngineState, &msg);
         }
     }

--- a/src/engine/engine.mc
+++ b/src/engine/engine.mc
@@ -967,7 +967,35 @@ MessageId=501
 Severity=Warning
 SymbolicName=MSG_STATE_NOT_SAVED
 Language=English
-The state file could not be saved. Continuing...
+The state file could not be saved, error: %1!ls!. Continuing...
+.
+
+MessageId=502
+Severity=Success
+SymbolicName=MSG_CLEANUP_BEGIN
+Language=English
+Cleanup begin.
+.
+
+MessageId=503
+Severity=Success
+SymbolicName=MSG_CLEANUP_SKIPPED_APPLY
+Language=English
+Cleanup not required due to running Apply.
+.
+
+MessageId=504
+Severity=Success
+SymbolicName=MSG_CLEANUP_SKIPPED_ELEVATION_REQUIRED
+Language=English
+Cleanup check skipped since this per-machine bundle would require elevation.
+.
+
+MessageId=599
+Severity=Success
+SymbolicName=MSG_CLEANUP_COMPLETE
+Language=English
+Cleanup complete, result: 0x%1!x!
 .
 
 MessageId=600


### PR DESCRIPTION
Add `::Sleep(0)` in engine loop to unblock `PostThreadMessage`

https://github.com/wixtoolset/issues/issues/6297