### PR TITLE
Correctly handle missing/null values with ~<> operator.

### DIFF
--- a/src/engine/condition.cpp
+++ b/src/engine/condition.cpp
@@ -896,7 +896,7 @@ static HRESULT CompareOperands(
     else
     {
         // not a combination that can be compared
-        *pfResult = (BURN_SYMBOL_TYPE_NE == comparison);
+        *pfResult = (BURN_SYMBOL_TYPE_NE == comparison || BURN_SYMBOL_TYPE_NE_I == comparison);
     }
 
 LExit:

--- a/src/test/BurnUnitTest/VariableTest.cpp
+++ b/src/test/BurnUnitTest/VariableTest.cpp
@@ -258,7 +258,10 @@ namespace Bootstrapper
                 Assert::True(EvaluateConditionHelper(&variables, L"PROP1 = \"VAL1\""));
                 Assert::False(EvaluateConditionHelper(&variables, L"NONE = \"NOT\""));
                 Assert::False(EvaluateConditionHelper(&variables, L"PROP1 <> \"VAL1\""));
+                Assert::False(EvaluateConditionHelper(&variables, L"PROP1 ~<> \"VAL1\""));
+                Assert::False(EvaluateConditionHelper(&variables, L"PROP1 ~<> \"Val1\""));
                 Assert::True(EvaluateConditionHelper(&variables, L"NONE <> \"NOT\""));
+                Assert::True(EvaluateConditionHelper(&variables, L"NONE ~<> \"NOT\""));
 
                 Assert::True(EvaluateConditionHelper(&variables, L"PROP1 ~= \"val1\""));
                 Assert::False(EvaluateConditionHelper(&variables, L"PROP1 = \"val1\""));


### PR DESCRIPTION
(That's case-insensitive non-equal.)

Fixes https://github.com/wixtoolset/issues/issues/5372