### PR TITLE
5702 - Ensure bundle is registered and cached when modifying machine state

### DIFF
--- a/src/engine/detect.cpp
+++ b/src/engine/detect.cpp
@@ -202,7 +202,7 @@ extern "C" HRESULT DetectReportRelatedBundles(
     HRESULT hr = S_OK;
     int nCompareResult = 0;
     BOOTSTRAPPER_REQUEST_STATE uninstallRequestState = BOOTSTRAPPER_REQUEST_STATE_NONE;
-    *pfEligibleForCleanup = pRegistration->fInstalled;
+    *pfEligibleForCleanup = pRegistration->fInstalled || CacheBundleRunningFromCache();
 
     for (DWORD iRelatedBundle = 0; iRelatedBundle < pRegistration->relatedBundles.cRelatedBundles; ++iRelatedBundle)
     {


### PR DESCRIPTION
Consider the bundle as eligible for cleanup if running from the cache.

Fixes https://github.com/wixtoolset/issues/issues/5702